### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from buster import version
 setup(name="buster",
       version=version,
       description="Static site generator for Ghost and Github",
-      long_description=open("README.md").read(),
+      long_description=open("README.rst").read(),
       author="Akshit Khurana",
       author_email="axitkhurana@gmail.com",
       url="https://github.com/boggin/buster",


### PR DESCRIPTION
Changed "README.md" to to "README.rst" to fix IOError when attempting pip install. 

Error was as follows, due to no such file as README.md in the skosh repo.
sudo -H python -m pip install git+https://github.com/skosch/buster
Collecting git+https://github.com/skosch/buster
  Cloning https://github.com/skosch/buster to /private/tmp/pip-req-build-yaeoZc
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/tmp/pip-req-build-yaeoZc/setup.py", line 10, in <module>
        long_description=open("README.md").read(),
    IOError: [Errno 2] No such file or directory: 'README.md'